### PR TITLE
Issue #6 fixed routing error caused by homepage in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://Harshal2502.github.io/BookCheff",
+  "homepage": "https://Harshal2502.github.io/",
   "name": "book-library",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
When opening this project via the npm start command it defaulted to localhost:3000/BookCheff, but there was no routing for this endpoint. The default should have been just localhost:3000/ but due to the homepage section in your package.json it was going to the other address. All I've done to fix this was remove the section of your homepage with that endpoint. 